### PR TITLE
Reduce enkf node usage

### DIFF
--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -69,7 +69,6 @@ typedef struct enkf_state_struct    enkf_state_type;
   void               enkf_state_swapin_node(const enkf_state_type *  , const char *);
   void               enkf_state_iset_eclpath(enkf_state_type * , int , const char *);
   enkf_node_type   * enkf_state_get_node(const enkf_state_type * , const char * );
-  bool               enkf_state_has_node(const enkf_state_type * enkf_state , const char * node_key);
   void               enkf_state_del_node(enkf_state_type * , const char * );
   void               enkf_state_load_ecl_summary(enkf_state_type * , bool , int );
   void             * enkf_state_run_eclipse__(void * );

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -96,7 +96,6 @@ typedef struct enkf_state_struct    enkf_state_type;
   void               enkf_state_update_jobname( enkf_state_type * enkf_state );
   void               enkf_state_update_eclbase( enkf_state_type * enkf_state );
   void               enkf_state_add_node(enkf_state_type * , const char *  , const enkf_config_node_type * );
-  enkf_node_type *   enkf_state_get_or_create_node(enkf_state_type * enkf_state, const enkf_config_node_type * config_node);
   void               enkf_state_load_ecl_restart(enkf_state_type * , bool , int );
   void               enkf_state_sample(enkf_state_type * , int);
   void               enkf_state_fwrite(const enkf_state_type *  , enkf_fs_type * fs , int  , int  );

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -98,7 +98,6 @@ typedef struct enkf_state_struct    enkf_state_type;
   void               enkf_state_add_node(enkf_state_type * , const char *  , const enkf_config_node_type * );
   void               enkf_state_load_ecl_restart(enkf_state_type * , bool , int );
   void               enkf_state_sample(enkf_state_type * , int);
-  void               enkf_state_fwrite(const enkf_state_type *  , enkf_fs_type * fs , int  , int  );
   void               enkf_state_ens_read(       enkf_state_type * , const char * , int);
   void               enkf_state_ecl_write(enkf_state_type *, const run_arg_type * run_arg , enkf_fs_type * fs);
   void               enkf_state_free(enkf_state_type * );

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -67,7 +67,7 @@ typedef struct enkf_state_struct    enkf_state_type;
   void               enkf_state_swapout_node(const enkf_state_type * , const char *);
   void               enkf_state_swapin_node(const enkf_state_type *  , const char *);
   void               enkf_state_iset_eclpath(enkf_state_type * , int , const char *);
-  enkf_node_type   * enkf_state_get_node(const enkf_state_type * , const char * );
+  //enkf_node_type   * enkf_state_get_node(const enkf_state_type * , const char * );
   void               enkf_state_load_ecl_summary(enkf_state_type * , bool , int );
   void             * enkf_state_run_eclipse__(void * );
   void             * enkf_state_start_forward_model__(void * );

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -64,7 +64,6 @@ typedef struct enkf_state_struct    enkf_state_type;
   //void             * enkf_state_complete_forward_model__(void * arg );
   void *             enkf_state_load_from_forward_model_mt( void * arg );
   void               enkf_state_initialize(enkf_state_type * enkf_state , enkf_fs_type * fs, const stringlist_type * param_list , init_mode_type init_mode);
-  void               enkf_state_fread(enkf_state_type *  , enkf_fs_type * fs , int  , int );
   void               enkf_state_swapout_node(const enkf_state_type * , const char *);
   void               enkf_state_swapin_node(const enkf_state_type *  , const char *);
   void               enkf_state_iset_eclpath(enkf_state_type * , int , const char *);

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -69,7 +69,6 @@ typedef struct enkf_state_struct    enkf_state_type;
   void               enkf_state_swapin_node(const enkf_state_type *  , const char *);
   void               enkf_state_iset_eclpath(enkf_state_type * , int , const char *);
   enkf_node_type   * enkf_state_get_node(const enkf_state_type * , const char * );
-  void               enkf_state_del_node(enkf_state_type * , const char * );
   void               enkf_state_load_ecl_summary(enkf_state_type * , bool , int );
   void             * enkf_state_run_eclipse__(void * );
   void             * enkf_state_start_forward_model__(void * );

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -139,6 +139,8 @@ static void enkf_state_fread_initial_state(enkf_state_type * enkf_state , enkf_f
 
 static enkf_node_type * enkf_state_get_or_create_node(enkf_state_type * enkf_state, const enkf_config_node_type * config_node);
 
+static void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step );
+
 /*****************************************************************/
 
 static UTIL_SAFE_CAST_FUNCTION( enkf_state , ENKF_STATE_TYPE_ID )

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -137,6 +137,8 @@ static void enkf_state_fread_state_nodes(enkf_state_type * enkf_state , enkf_fs_
 
 static void enkf_state_fread_initial_state(enkf_state_type * enkf_state , enkf_fs_type * fs);
 
+static enkf_node_type * enkf_state_get_or_create_node(enkf_state_type * enkf_state, const enkf_config_node_type * config_node);
+
 /*****************************************************************/
 
 static UTIL_SAFE_CAST_FUNCTION( enkf_state , ENKF_STATE_TYPE_ID )

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -141,6 +141,8 @@ static enkf_node_type * enkf_state_get_or_create_node(enkf_state_type * enkf_sta
 
 static void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step );
 
+static enkf_node_type * enkf_state_get_node(const enkf_state_type * enkf_state , const char * node_key);
+
 /*****************************************************************/
 
 static UTIL_SAFE_CAST_FUNCTION( enkf_state , ENKF_STATE_TYPE_ID )

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -279,19 +279,6 @@ static void enkf_state_fread_initial_state(enkf_state_type * enkf_state , enkf_f
 }
 
 
-void enkf_state_free_nodes(enkf_state_type * enkf_state, int mask) {
-  const int num_keys = hash_get_size(enkf_state->node_hash);
-  char ** key_list   = hash_alloc_keylist(enkf_state->node_hash);
-  int ikey;
-
-  for (ikey = 0; ikey < num_keys; ikey++) {
-    enkf_node_type * enkf_node = hash_get(enkf_state->node_hash , key_list[ikey]);
-    if (enkf_node_include_type(enkf_node , mask))
-      enkf_state_del_node(enkf_state , enkf_node_get_key(enkf_node));
-  }
-  util_free_stringlist(key_list , num_keys);
-}
-
 
 
 enkf_node_type * enkf_state_get_node(const enkf_state_type * enkf_state , const char * node_key) {

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -43,14 +43,13 @@ void enkf_state_add_node(enkf_state_type * enkf_state , const char * node_key , 
 }
 
 
-enkf_node_type * enkf_state_get_or_create_node(enkf_state_type * enkf_state, const enkf_config_node_type * config_node) {
+static enkf_node_type * enkf_state_get_or_create_node(enkf_state_type * enkf_state, const enkf_config_node_type * config_node) {
     const char * key = enkf_config_node_get_key(config_node);
     if(!enkf_state_has_node(enkf_state, key)) {
         enkf_state_add_node(enkf_state, key, config_node);
     }
     return enkf_state_get_node(enkf_state, key);
 }
-
 
 /**
    This function loads the STATE from a forward simulation. In ECLIPSE

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -1,7 +1,8 @@
-bool enkf_state_has_node(const enkf_state_type * enkf_state , const char * node_key) {
+static bool enkf_state_has_node(const enkf_state_type * enkf_state , const char * node_key) {
   bool has_node = hash_has_key(enkf_state->node_hash , node_key);
   return has_node;
 }
+
 
 
 /**

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -176,7 +176,7 @@ int enkf_state_forward_init(enkf_state_type * enkf_state ,
 
 
 
-void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step ) {
+static void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step ) {
   const member_config_type * my_config = enkf_state->my_config;
   const int num_keys = hash_get_size(enkf_state->node_hash);
   char ** key_list   = hash_alloc_keylist(enkf_state->node_hash);
@@ -196,7 +196,6 @@ void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mas
   }
   util_free_stringlist(key_list , num_keys);
 }
-
 
 
 /**

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -280,8 +280,7 @@ static void enkf_state_fread_initial_state(enkf_state_type * enkf_state , enkf_f
 
 
 
-
-enkf_node_type * enkf_state_get_node(const enkf_state_type * enkf_state , const char * node_key) {
+static enkf_node_type * enkf_state_get_node(const enkf_state_type * enkf_state , const char * node_key) {
   if (hash_has_key(enkf_state->node_hash , node_key)) {
     enkf_node_type * enkf_node = hash_get(enkf_state->node_hash , node_key);
     return enkf_node;

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -4,6 +4,14 @@ static bool enkf_state_has_node(const enkf_state_type * enkf_state , const char 
 }
 
 
+static void enkf_state_del_node(enkf_state_type * enkf_state , const char * node_key) {
+  if (hash_has_key(enkf_state->node_hash , node_key))
+    hash_del(enkf_state->node_hash , node_key);
+  else
+    fprintf(stderr,"%s: tried to remove node:%s which is not in state - internal error?? \n",__func__ , node_key);
+}
+
+
 
 /**
    The enkf_state inserts a reference to the node object. The
@@ -323,9 +331,3 @@ enkf_node_type * enkf_state_get_node(const enkf_state_type * enkf_state , const 
 
 
 
-void enkf_state_del_node(enkf_state_type * enkf_state , const char * node_key) {
-  if (hash_has_key(enkf_state->node_hash , node_key))
-    hash_del(enkf_state->node_hash , node_key);
-  else
-    fprintf(stderr,"%s: tried to remove node:%s which is not in state - internal error?? \n",__func__ , node_key);
-}

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -175,29 +175,6 @@ int enkf_state_forward_init(enkf_state_type * enkf_state ,
 
 
 
-/**
-  This function takes a report_step and a analyzed|forecast state as
-  input; the enkf_state instance is set accordingly and written to
-  disk.
-*/
-
-
-void enkf_state_fwrite(const enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step ) {
-  const member_config_type * my_config = enkf_state->my_config;
-  const int num_keys = hash_get_size(enkf_state->node_hash);
-  char ** key_list   = hash_alloc_keylist(enkf_state->node_hash);
-  int ikey;
-
-  for (ikey = 0; ikey < num_keys; ikey++) {
-    enkf_node_type * enkf_node = hash_get(enkf_state->node_hash , key_list[ikey]);
-    if (enkf_node_include_type(enkf_node , mask)) {
-      node_id_type node_id = {.report_step = report_step , .iens = member_config_get_iens( my_config ) };
-      enkf_node_store( enkf_node, fs , true , node_id );
-    }
-  }
-  util_free_stringlist(key_list , num_keys);
-}
-
 
 void enkf_state_fread(enkf_state_type * enkf_state , enkf_fs_type * fs , int mask , int report_step ) {
   const member_config_type * my_config = enkf_state->my_config;

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -20,6 +20,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <ert/util/rng.h>
+#include <ert/util/mzran.h>
 #include <ert/util/test_util.h>
 #include <ert/util/test_work_area.h>
 #include <ert/util/util.h>
@@ -42,6 +44,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter ) {
 
 int main(int argc , char ** argv) {
   enkf_main_install_SIGNALS();
+  rng_type * rng = rng_alloc( MZRAN , INIT_DEFAULT );
   const char * root_path = argv[1];
   const char * config_file = argv[2];
   const char * forward_init_string = argv[3];
@@ -57,10 +60,10 @@ int main(int argc , char ** argv) {
     util_clear_directory( "Storage" , true , true );
     enkf_main = enkf_main_bootstrap( config_file , strict , true );
     {
-      enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
-      enkf_node_type * gen_kw_node = enkf_state_get_node( state , "MULTFLT" );
+      const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "MULTFLT" );
+      enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );
       {
-        const enkf_config_node_type * gen_kw_config_node = enkf_node_get_config( gen_kw_node );
+
         char * init_file1 = enkf_config_node_alloc_initfile( gen_kw_config_node , NULL , 0);
         char * init_file2 = enkf_config_node_alloc_initfile( gen_kw_config_node , "/tmp", 0);
 
@@ -74,8 +77,9 @@ int main(int argc , char ** argv) {
 
       test_assert_bool_equal( enkf_node_use_forward_init( gen_kw_node ) , forward_init );
       if (forward_init)
-        test_assert_bool_not_equal( enkf_node_initialize( gen_kw_node , 0 , enkf_state_get_rng( state )) , forward_init);
+        test_assert_bool_not_equal( enkf_node_initialize( gen_kw_node , 0 , rng) , forward_init);
       // else hard_failure()
+      enkf_node_free( gen_kw_node );
     }
     test_assert_bool_equal( forward_init, ensemble_config_have_forward_init( enkf_main_get_ensemble_config( enkf_main )));
 
@@ -83,7 +87,8 @@ int main(int argc , char ** argv) {
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( fs , 0 , 0 , "simulations/run0");
-      enkf_node_type * gen_kw_node = enkf_state_get_node( state , "MULTFLT" );
+      const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ), "MULTFLT");
+      enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 
@@ -156,8 +161,10 @@ int main(int argc , char ** argv) {
       }
       util_clear_directory( "simulations" , true , true );
       run_arg_free( run_arg );
+      enkf_node_free( gen_kw_node );
     }
     enkf_main_free( enkf_main );
   }
   test_work_area_free( work_area );
+  rng_free( rng );
 }

--- a/libenkf/tests/gen_kw_test.c
+++ b/libenkf/tests/gen_kw_test.c
@@ -39,42 +39,32 @@
 
 void test_send_fortio_to_gen_kw_ecl_write(void * arg) {
   enkf_main_type * enkf_main = arg;
-  test_assert_not_NULL(enkf_main);
   fortio_type * fortio  = fortio_open_writer("my_new_file", false, ECL_ENDIAN_FLIP);
-  test_assert_not_NULL(fortio);
-
-  enkf_state_type * state  = enkf_main_iget_state( enkf_main , 0 );
-  test_assert_not_NULL(state);
-  enkf_node_type * enkf_node = enkf_state_get_node( state , "MULTFLT" );
-  test_assert_not_NULL(enkf_node);
-  const enkf_config_node_type * config_node = enkf_node_get_config(enkf_node);
-  test_assert_not_NULL(config_node);
+  const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ), "MULTFLT");
+  enkf_node_type * enkf_node = enkf_node_alloc( config_node );
 
   if (GEN_KW == enkf_config_node_get_impl_type(config_node)) {
     const char * dummy_path = "dummy_path";
     enkf_node_ecl_write(enkf_node, dummy_path, fortio, 0);
   }
+
+  enkf_node_free( enkf_node );
+  fortio_fclose( fortio );
 }
 
 
 void test_write_gen_kw_export_file(enkf_main_type * enkf_main)
 {
-  test_assert_not_NULL(enkf_main);
-  enkf_fs_type * init_fs = enkf_main_get_fs( enkf_main );
-  enkf_state_type * state = enkf_main_iget_state( enkf_main , 0 );
-  run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( init_fs , 0 ,0 , "simulations/run0");
-  test_assert_not_NULL(state);
-  enkf_node_type * enkf_node = enkf_state_get_node( state , "MULTFLT" );
-
-  test_assert_not_NULL(enkf_node);
-  const enkf_config_node_type * config_node = enkf_node_get_config(enkf_node);
-  test_assert_not_NULL(config_node);
-
+  const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ), "MULTFLT");
   if (GEN_KW == enkf_config_node_get_impl_type(config_node)) {
+    enkf_state_type * state = enkf_main_iget_state( enkf_main , 0 );
+    enkf_fs_type * init_fs = enkf_main_get_fs( enkf_main );
+    run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( init_fs , 0 ,0 , "simulations/run0");
     enkf_state_ecl_write(state, run_arg , init_fs);
     test_assert_true(util_file_exists("simulations/run0/parameters.txt"));
-  }
-  run_arg_free( run_arg );
+    run_arg_free( run_arg );
+  } else
+    util_exit("Test configuration error \n");
 }
 
 

--- a/python/python/ert/enkf/enkf_state.py
+++ b/python/python/ert/enkf/enkf_state.py
@@ -22,8 +22,6 @@ from ert.job_queue import JobStatusType
 class EnKFState(BaseCClass):
     TYPE_NAME       = "enkf_state"
     _free           = EnkfPrototype("void* enkf_state_free( enkf_state )")
-    _has_key        = EnkfPrototype("bool  enkf_state_has_node( enkf_state , char* )")
-    _get_node       = EnkfPrototype("enkf_node_ref  enkf_state_has_node( enkf_state , char* )")
     _add_subst_kw   = EnkfPrototype("void enkf_state_add_subst_kw( enkf_state , char* , char* , char*)")
     _get_subst_list = EnkfPrototype("subst_list_ref enkf_state_get_subst_list( enkf_state )")
     _get_ens_config = EnkfPrototype("ens_config_ref enkf_state_get_ensemble_config( enkf_state )")
@@ -33,32 +31,6 @@ class EnKFState(BaseCClass):
         raise NotImplementedError("Class can not be instantiated directly!")
         
     
-    def __getitem__(self , kw):
-        """ @rtype: ert.enkf.data.enkf_node.EnkfNode """
-        if isinstance(kw , str):
-            if kw in self:
-                node = self._get_node( kw )
-                node.setParent( self )
-                return node
-            else:
-                raise KeyError("The state object does not have node:%s" % kw)
-        else:
-            raise TypeError("The kw type must be string. Input:%s" % kw)
-
-
-    def __contains__(self , kw):
-        return self._has_key( kw )
-
-
-    def hasKey(self , kw):
-        """ @rtype: bool """
-        return kw in self
-
-
-    def getNode(self , kw):
-        """ @rtype: ert.enkf.data.enkf_node.EnkfNode """
-        return self[kw]
-
 
     def free(self):
         self._free( )


### PR DESCRIPTION
Reduced usage of the `node_hash` field in the `enkf_state` structure. This is a step in the direction of less state maintenance in the application.