### PR TITLE
Remove job queue arg

### DIFF
--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -118,10 +118,10 @@ typedef struct enkf_state_struct    enkf_state_type;
 
 /******************************************************************/
 /* Forward model callbacks: */
+  bool enkf_state_complete_forward_modelOK__(void * arg );
+  bool enkf_state_complete_forward_modelRETRY__(void * arg );
+  bool enkf_state_complete_forward_modelEXIT__(void * arg );
 
-bool enkf_state_complete_forward_modelOK__(job_queue_type * job_queue, void * arg );
-bool enkf_state_complete_forward_modelRETRY__(job_queue_type * job_queue, void * arg );
-bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * arg );
 
 #ifdef __cplusplus
 }

--- a/libenkf/include/ert/enkf/queue_config.h
+++ b/libenkf/include/ert/enkf/queue_config.h
@@ -43,7 +43,7 @@ typedef struct queue_config_struct queue_config_type;
     void queue_config_init_user_mode(queue_config_type * queue_config);
     bool queue_config_init(queue_config_type * queue_config, const config_content_type * config);
 
-    int queue_config_get_max_submit(queue_config_type * queue_config);    
+    int queue_config_get_max_submit(queue_config_type * queue_config);
     bool queue_config_has_job_script( const queue_config_type * queue_config );
     const char * queue_config_get_job_script(const queue_config_type * queue_config);
     bool queue_config_set_job_script(queue_config_type * queue_config, const char * job_script);
@@ -58,11 +58,7 @@ typedef struct queue_config_struct queue_config_type;
 
     void queue_config_add_config_items(config_parser_type * parser, bool site_mode);
 
-    //job_queue_type * queue_config_alloc_job_queue(const queue_config_type * queue_config);
-    job_queue_type * queue_config_alloc_job_queue(const queue_config_type * queue_config, 
-                                              job_callback_ftype * done_callback,
-                                              job_callback_ftype * retry_callback,
-                                              job_callback_ftype * exit_callback);
+    job_queue_type * queue_config_alloc_job_queue(const queue_config_type * queue_config);
 
 #ifdef __cplusplus
 }

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1383,7 +1383,10 @@ void enkf_main_isubmit_job( enkf_main_type * enkf_main , run_arg_type * run_arg 
 
   {
     int queue_index = job_queue_add_job( job_queue ,
-                                         job_script ,                                         
+                                         job_script ,
+                                         enkf_state_complete_forward_modelOK__,
+                                         enkf_state_complete_forward_modelRETRY__,
+                                         enkf_state_complete_forward_modelEXIT__,
                                          callback_arg ,
                                          ecl_config_get_num_cpu( ecl_config ),
                                          run_path ,
@@ -1563,10 +1566,7 @@ static int enkf_main_run_step(enkf_main_type * enkf_main       ,
     job_size = bool_vector_count_equal( ert_run_context_get_iactive(run_context) , true );
     {
       const queue_config_type * queue_config = site_config_get_queue_config(enkf_main->site_config);
-      job_queue_type * job_queue = queue_config_alloc_job_queue(queue_config,
-                                                                enkf_state_complete_forward_modelOK__,
-                                                                enkf_state_complete_forward_modelRETRY__,
-                                                                enkf_state_complete_forward_modelEXIT__ );
+      job_queue_type * job_queue = queue_config_alloc_job_queue(queue_config);
       job_queue_manager_type * queue_manager = job_queue_manager_alloc( job_queue );
       bool restart_queue = true;
 

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -1078,11 +1078,6 @@ void enkf_state_init_eclipse(enkf_state_type *enkf_state, const run_arg_type * r
 
 
 
-bool enkf_state_complete_forward_modelOK__(job_queue_type * job_queue, void * arg );
-bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * arg );
-bool enkf_state_complete_forward_modelRETRY__(job_queue_type * job_queue, void * arg );
-
-
 
 
 
@@ -1166,7 +1161,7 @@ static bool enkf_state_complete_forward_modelOK(enkf_state_type * enkf_state , r
 }
 
 
-bool enkf_state_complete_forward_modelOK__(job_queue_type * job_queue, void * arg ) {
+bool enkf_state_complete_forward_modelOK__(void * arg ) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
   enkf_state_type * enkf_state = enkf_state_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ));
   run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1 ));
@@ -1176,7 +1171,7 @@ bool enkf_state_complete_forward_modelOK__(job_queue_type * job_queue, void * ar
 
 
 
-static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue ) {
+static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state , run_arg_type * run_arg) {
   const member_config_type  * my_config   = enkf_state->my_config;
   const int iens                          = member_config_get_iens( my_config );
   ert_log_add_fmt_message( 1, NULL, "[%03d:%04d-%04d] FAILED COMPLETELY.", iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
@@ -1190,18 +1185,18 @@ static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * e
 }
 
 
-static bool enkf_state_complete_forward_model_EXIT_handler(job_queue_type * job_queue, void * arg) {
+static bool enkf_state_complete_forward_model_EXIT_handler(void * arg) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
 
   enkf_state_type * enkf_state = enkf_state_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ) );
   run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1 ) );
 
-  return enkf_state_complete_forward_model_EXIT_handler__( enkf_state , run_arg , job_queue);
+  return enkf_state_complete_forward_model_EXIT_handler__( enkf_state , run_arg);
 }
 
 
-bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * arg ) {
-  return enkf_state_complete_forward_model_EXIT_handler(job_queue, arg);
+bool enkf_state_complete_forward_modelEXIT__(void * arg ) {
+  return enkf_state_complete_forward_model_EXIT_handler(arg);
 }
 
 
@@ -1220,7 +1215,7 @@ bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * 
 
 
 
-static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue) {
+static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_type * run_arg) {
   const member_config_type  * my_config   = enkf_state->my_config;
   const int iens                          = member_config_get_iens( my_config );
 
@@ -1243,13 +1238,13 @@ static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_typ
 }
 
 
-bool enkf_state_complete_forward_modelRETRY__(job_queue_type * job_queue, void * arg ) {
+bool enkf_state_complete_forward_modelRETRY__(void * arg ) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
   enkf_state_type * enkf_state = enkf_state_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ) );
   run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1 ) );
 
   if (run_arg_can_retry(run_arg)) {
-    enkf_state_internal_retry(enkf_state, run_arg , job_queue );
+    enkf_state_internal_retry(enkf_state, run_arg);
     return true;
   } else {
     return false;

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -1083,47 +1083,6 @@ bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * 
 bool enkf_state_complete_forward_modelRETRY__(job_queue_type * job_queue, void * arg );
 
 
-/**
-    This function is called when:
-
-     1. The external queue system has said that everything is OK; BUT
-        the ert layer failed to load all the data.
-
-     2. The external queue system has seen the job fail.
-
-    The parameter and state variables will be resampled before
-    retrying. And all random elements in templates+++ will be
-    resampled.
-*/
-
-
-
-static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue , bool load_failure) {
-  const member_config_type  * my_config   = enkf_state->my_config;
-  const int iens                          = member_config_get_iens( my_config );
-
-  if (load_failure)
-    ert_log_add_fmt_message( 1 , NULL , "[%03d:%04d - %04d] Failed to load all data.",iens , run_arg_get_step1(run_arg) , run_arg_get_step2(run_arg));
-  else
-    ert_log_add_fmt_message( 1 , NULL , "[%03d:%04d - %04d] Forward model failed.",iens, run_arg_get_step1(run_arg) , run_arg_get_step2(run_arg));
-
-  if (run_arg_can_retry( run_arg ) ) {
-    ert_log_add_fmt_message( 1 , NULL , "[%03d] Resampling and resubmitting realization." ,iens);
-    {
-      /* Reinitialization of the nodes */
-      stringlist_type * init_keys = ensemble_config_alloc_keylist_from_var_type( enkf_state->ensemble_config , DYNAMIC_STATE + PARAMETER );
-      for (int ikey=0; ikey < stringlist_get_size( init_keys ); ikey++) {
-        enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( init_keys , ikey) );
-        enkf_node_initialize( node , iens , enkf_state->rng );
-      }
-      stringlist_free( init_keys );
-    }
-
-    enkf_state_init_eclipse( enkf_state , run_arg  );                                               /* Possibly clear the directory and do a FULL rewrite of ALL the necessary files. */
-    job_queue_iset_external_restart( job_queue , run_arg_get_queue_index(run_arg) );   /* Here we inform the queue system that it should pick up this job and try again. */
-    run_arg_increase_submit_count( run_arg );
-  }
-}
 
 
 
@@ -1217,51 +1176,84 @@ bool enkf_state_complete_forward_modelOK__(job_queue_type * job_queue, void * ar
 
 
 
-static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue , bool is_retry) {
+static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue ) {
   const member_config_type  * my_config   = enkf_state->my_config;
   const int iens                          = member_config_get_iens( my_config );
-  /*
-     The external queue system has said that the job failed - we
-     might give it another try from this scope, possibly involving a
-     resampling.
-   */
+  ert_log_add_fmt_message( 1, NULL, "[%03d:%04d-%04d] FAILED COMPLETELY.", iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
 
-  if (is_retry) {
-    if (run_arg_can_retry(run_arg)) {
-      enkf_state_internal_retry(enkf_state, run_arg , job_queue , false);
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    ert_log_add_fmt_message( 1, NULL, "[%03d:%04d-%04d] FAILED COMPLETELY.", iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
+  if (run_arg_get_run_status(run_arg) != JOB_LOAD_FAILURE)
+    run_arg_set_run_status( run_arg , JOB_RUN_FAILURE);
 
-    if (run_arg_get_run_status(run_arg) != JOB_LOAD_FAILURE)
-      run_arg_set_run_status( run_arg , JOB_RUN_FAILURE);
-
-    state_map_type * state_map = enkf_fs_get_state_map(run_arg_get_result_fs( run_arg ));
-    int iens = member_config_get_iens(enkf_state->my_config);
-    state_map_iset(state_map, iens, STATE_LOAD_FAILURE);
-    return false;
-  }
+  state_map_type * state_map = enkf_fs_get_state_map(run_arg_get_result_fs( run_arg ));
+  state_map_iset(state_map, iens, STATE_LOAD_FAILURE);
+  return false;
 }
 
-static bool enkf_state_complete_forward_model_EXIT_handler(job_queue_type * job_queue, void * arg, bool allow_retry ) {
+
+static bool enkf_state_complete_forward_model_EXIT_handler(job_queue_type * job_queue, void * arg) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
 
   enkf_state_type * enkf_state = enkf_state_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ) );
   run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1 ) );
 
-  return enkf_state_complete_forward_model_EXIT_handler__( enkf_state , run_arg , job_queue, allow_retry );
+  return enkf_state_complete_forward_model_EXIT_handler__( enkf_state , run_arg , job_queue);
 }
 
 
 bool enkf_state_complete_forward_modelEXIT__(job_queue_type * job_queue, void * arg ) {
-  return enkf_state_complete_forward_model_EXIT_handler(job_queue, arg, false );
+  return enkf_state_complete_forward_model_EXIT_handler(job_queue, arg);
 }
 
+
+/**
+    This function is called when:
+
+     1. The external queue system has said that everything is OK; BUT
+        the ert layer failed to load all the data.
+
+     2. The external queue system has seen the job fail.
+
+    The parameter and state variables will be resampled before
+    retrying. And all random elements in templates+++ will be
+    resampled.
+*/
+
+
+
+static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_type * run_arg , job_queue_type * job_queue) {
+  const member_config_type  * my_config   = enkf_state->my_config;
+  const int iens                          = member_config_get_iens( my_config );
+
+  ert_log_add_fmt_message( 1 , NULL , "[%03d:%04d - %04d] Forward model failed.",iens, run_arg_get_step1(run_arg) , run_arg_get_step2(run_arg));
+  if (run_arg_can_retry( run_arg ) ) {
+    ert_log_add_fmt_message( 1 , NULL , "[%03d] Resampling and resubmitting realization." ,iens);
+    {
+      /* Reinitialization of the nodes */
+      stringlist_type * init_keys = ensemble_config_alloc_keylist_from_var_type( enkf_state->ensemble_config , DYNAMIC_STATE + PARAMETER );
+      for (int ikey=0; ikey < stringlist_get_size( init_keys ); ikey++) {
+        enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( init_keys , ikey) );
+        enkf_node_initialize( node , iens , enkf_state->rng );
+      }
+      stringlist_free( init_keys );
+    }
+
+    enkf_state_init_eclipse( enkf_state , run_arg  );                                  /* Possibly clear the directory and do a FULL rewrite of ALL the necessary files. */
+    run_arg_increase_submit_count( run_arg );
+  }
+}
+
+
 bool enkf_state_complete_forward_modelRETRY__(job_queue_type * job_queue, void * arg ) {
-  return enkf_state_complete_forward_model_EXIT_handler(job_queue, arg, true );
+  arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
+  enkf_state_type * enkf_state = enkf_state_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ) );
+  run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1 ) );
+
+  if (run_arg_can_retry(run_arg)) {
+    enkf_state_internal_retry(enkf_state, run_arg , job_queue );
+    return true;
+  } else {
+    return false;
+  }
 }
 
 

--- a/libenkf/src/queue_config.c
+++ b/libenkf/src/queue_config.c
@@ -57,23 +57,18 @@ queue_config_type * queue_config_alloc() {
     return queue_config;
 }
 
-job_queue_type * queue_config_alloc_job_queue(const queue_config_type * queue_config, 
-                                              job_callback_ftype * done_callback,
-                                              job_callback_ftype * retry_callback,
-                                              job_callback_ftype * exit_callback) {
-    job_queue_type * job_queue = job_queue_alloc_w_callback(DEFAULT_MAX_SUBMIT, "OK", "STATUS", "ERROR", 
-                                                            done_callback,
-                                                            retry_callback,
-                                                            exit_callback);
-    const char * driver_name = queue_config_get_queue_name(queue_config);
-    if (driver_name != NULL) 
+job_queue_type * queue_config_alloc_job_queue(const queue_config_type * queue_config) {
+  job_queue_type * job_queue = job_queue_alloc(DEFAULT_MAX_SUBMIT, "OK", "STATUS", "ERROR");
+  const char * driver_name = queue_config_get_queue_name(queue_config);
+  if (driver_name != NULL)
     {
         queue_driver_type * driver = queue_config_get_queue_driver(queue_config, driver_name);
         job_queue_set_driver(job_queue, driver);
-    }  
-    if (queue_config->max_submit_set)
-        job_queue_set_max_submit(job_queue, queue_config->max_submit);
-    return job_queue;
+    }
+
+  if (queue_config->max_submit_set)
+    job_queue_set_max_submit(job_queue, queue_config->max_submit);
+  return job_queue;
 }
 
 void queue_config_free(queue_config_type * queue_config) {

--- a/libenkf/tests/enkf_queue_config.c
+++ b/libenkf/tests/enkf_queue_config.c
@@ -72,7 +72,7 @@ void test_parse() {
    test_assert_string_equal(queue_config_get_queue_name(queue_config), LSF_DRIVER_NAME);
 
    //test for licence path
-   job_queue_type * job_queue = queue_config_alloc_job_queue(queue_config, NULL, NULL, NULL);
+   job_queue_type * job_queue = queue_config_alloc_job_queue(queue_config);
    test_assert_double_equal(job_queue_get_max_submit(job_queue), 6);
 
 

--- a/libjob_queue/include/ert/job_queue/job_node.h
+++ b/libjob_queue/include/ert/job_queue/job_node.h
@@ -3,7 +3,7 @@
 
    The file 'job_node.h' is part of ERT - Ensemble based Reservoir Tool.
 
-   ERT is free software: you can redistribute illt and/or modify
+   ERT is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
@@ -28,7 +28,6 @@ extern "C" {
 #include <ert/job_queue/queue_driver.h>
 #include <ert/job_queue/job_queue_status.h>
 
-
 /**
    This struct holds the job_queue information about one job. Observe
    the following:
@@ -47,6 +46,7 @@ extern "C" {
 
 */
 
+typedef bool (job_callback_ftype)   (void *);
 typedef struct job_queue_node_struct job_queue_node_type;
 
 
@@ -66,7 +66,10 @@ typedef struct job_queue_node_struct job_queue_node_type;
                                               int num_cpu ,
                                               const char * ok_file,
                                               const char * status_file,
-                                              const char * exit_file,                                              
+                                              const char * exit_file,
+                                              job_callback_ftype * done_callback,
+                                              job_callback_ftype * retry_callback,
+                                              job_callback_ftype * exit_callback,
                                               void * callback_arg);
 
 
@@ -103,11 +106,13 @@ typedef struct job_queue_node_struct job_queue_node_type;
   const char * job_queue_node_get_status_file( const job_queue_node_type * node);
   const char * job_queue_node_get_exit_file( const job_queue_node_type * node);
 
+  bool job_queue_node_run_DONE_callback( job_queue_node_type * node );
+  bool job_queue_node_run_RETRY_callback( job_queue_node_type * node );
+  void job_queue_node_run_EXIT_callback( job_queue_node_type * node );
   int job_queue_node_get_queue_index( const job_queue_node_type * node );
   void job_queue_node_set_queue_index( job_queue_node_type * node , int queue_index);
 
   void * job_queue_node_get_driver_data( job_queue_node_type * node );
-  void * job_queue_node_get_callback_arg(job_queue_node_type * node);
 
   UTIL_IS_INSTANCE_HEADER( job_queue_node );
   UTIL_SAFE_CAST_HEADER( job_queue_node );

--- a/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/libjob_queue/include/ert/job_queue/job_queue.h
@@ -32,7 +32,7 @@ extern "C" {
 
   
   typedef struct job_queue_struct      job_queue_type;
-  typedef bool (job_callback_ftype)   (job_queue_type *, void *);
+  typedef bool (job_callback_ftype)    (void *);
 
   void                job_queue_submit_complete( job_queue_type * queue );
   job_driver_type     job_queue_get_driver_type( const job_queue_type * queue );

--- a/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/libjob_queue/include/ert/job_queue/job_queue.h
@@ -30,9 +30,8 @@ extern "C" {
 #include <ert/job_queue/job_node.h>
 
 
-  
   typedef struct job_queue_struct      job_queue_type;
-  typedef bool (job_callback_ftype)    (void *);
+
 
   void                job_queue_submit_complete( job_queue_type * queue );
   job_driver_type     job_queue_get_driver_type( const job_queue_type * queue );
@@ -40,26 +39,14 @@ extern "C" {
   bool                job_queue_has_driver(const job_queue_type * queue );
   //void                job_queue_set_size( job_queue_type * job_queue , int size );
   void                job_queue_set_runpath_fmt(job_queue_type *  , const path_fmt_type * );
-  //job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * status_file, const char * exit_file);
-
-  job_queue_type * job_queue_alloc_w_callback(int  max_submit,
-                                              const char * ok_file ,
-                                              const char * status_file ,
-                                              const char * exit_file,
-                                              job_callback_ftype * done_callback,
-                                              job_callback_ftype * retry_callback,
-                                              job_callback_ftype * exit_callback);
-
-  job_queue_type * job_queue_alloc(int  max_submit,
-                                   const char * ok_file ,
-                                   const char * status_file ,
-                                   const char * exit_file);
-
-
+  job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * status_file, const char * exit_file);
   void                job_queue_free(job_queue_type *);
 
   int                 job_queue_add_job(job_queue_type * ,
                                         const char * run_cmd ,
+                                        job_callback_ftype * done_callback,
+                                        job_callback_ftype * retry_callback,
+                                        job_callback_ftype * exit_callback,
                                         void * callback_arg ,
                                         int num_cpu ,
                                         const char * ,
@@ -118,7 +105,6 @@ extern "C" {
   bool                job_queue_has_driver(const job_queue_type * queue );
   job_queue_node_type * job_queue_iget_node(job_queue_type * queue , int job_index);
   int job_queue_get_max_running( const job_queue_type * queue );
-
 
   UTIL_SAFE_CAST_HEADER( job_queue );
 

--- a/libjob_queue/src/job_queue.c
+++ b/libjob_queue/src/job_queue.c
@@ -699,7 +699,7 @@ static bool job_queue_run_DONE_callback__(job_queue_type * job_queue, job_queue_
    job_callback_ftype * callback_DONE = job_queue->done_callback; 
    void * callback_arg = job_queue_node_get_callback_arg( node );
    if (callback_DONE)
-       OK = callback_DONE(job_queue, callback_arg );
+       OK = callback_DONE(callback_arg );
    
    return OK;
 }
@@ -709,7 +709,7 @@ static bool job_queue_run_RETRY_callback__(job_queue_type * job_queue, job_queue
   job_callback_ftype * callback_RETRY = job_queue->retry_callback; 
   void * callback_arg = job_queue_node_get_callback_arg( node );
   if (callback_RETRY)
-    retry = callback_RETRY(job_queue, callback_arg );
+    retry = callback_RETRY(callback_arg );
 
   return retry;
 }
@@ -718,7 +718,7 @@ static void job_queue_run_EXIT_callback__( job_queue_type * job_queue , job_queu
   job_callback_ftype * callback_EXIT = job_queue->exit_callback; 
   void * callback_arg = job_queue_node_get_callback_arg( node );
   if (callback_EXIT)
-    callback_EXIT(job_queue, callback_arg );
+    callback_EXIT(callback_arg );
 }
 
 

--- a/libjob_queue/src/job_queue.c
+++ b/libjob_queue/src/job_queue.c
@@ -231,9 +231,6 @@ struct job_queue_struct {
   unsigned long              usleep_time;                       /* The sleep time before checking for updates. */
   pthread_mutex_t            run_mutex;                         /* This mutex is used to ensure that ONLY one thread is executing the job_queue_run_jobs(). */
   thread_pool_type         * work_pool;
-  job_callback_ftype *       done_callback;
-  job_callback_ftype *       retry_callback;
-  job_callback_ftype *       exit_callback;
 };
 
 
@@ -694,34 +691,6 @@ static bool job_queue_check_node_status_files( const job_queue_type * job_queue 
 }
 
 
-static bool job_queue_run_DONE_callback__(job_queue_type * job_queue, job_queue_node_type * node) {
-   bool OK = true;
-   job_callback_ftype * callback_DONE = job_queue->done_callback; 
-   void * callback_arg = job_queue_node_get_callback_arg( node );
-   if (callback_DONE)
-       OK = callback_DONE(callback_arg );
-   
-   return OK;
-}
-
-static bool job_queue_run_RETRY_callback__(job_queue_type * job_queue, job_queue_node_type * node ) {
-  bool retry = false;
-  job_callback_ftype * callback_RETRY = job_queue->retry_callback; 
-  void * callback_arg = job_queue_node_get_callback_arg( node );
-  if (callback_RETRY)
-    retry = callback_RETRY(callback_arg );
-
-  return retry;
-}
-
-static void job_queue_run_EXIT_callback__( job_queue_type * job_queue , job_queue_node_type * node ) {
-  job_callback_ftype * callback_EXIT = job_queue->exit_callback; 
-  void * callback_arg = job_queue_node_get_callback_arg( node );
-  if (callback_EXIT)
-    callback_EXIT(callback_arg );
-}
-
-
 static void * job_queue_run_DONE_callback( void * arg ) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
   job_queue_type * job_queue = arg_pack_iget_ptr( arg_pack , 0 );
@@ -731,9 +700,8 @@ static void * job_queue_run_DONE_callback( void * arg ) {
     job_queue_node_type * node = job_list_iget_job( job_queue->job_list , queue_index );
     bool OK = job_queue_check_node_status_files( job_queue , node );
 
-    if (OK) {
-      OK = job_queue_run_DONE_callback__(job_queue, node);
-    }
+    if (OK)
+      OK = job_queue_node_run_DONE_callback( node );
 
     if (OK)
       job_queue_change_node_status( job_queue , node , JOB_QUEUE_SUCCESS );
@@ -770,7 +738,7 @@ static void * job_queue_run_EXIT_callback( void * arg ) {
     if (job_queue_node_get_submit_attempt( node ) < job_queue->max_submit)
       job_queue_change_node_status( job_queue , node , JOB_QUEUE_WAITING );  /* The job will be picked up for antother go. */
     else {
-      bool retry = job_queue_run_RETRY_callback__(job_queue, node);
+      bool retry = job_queue_node_run_RETRY_callback( node );
 
       if (retry) {
         /* OK - we have invoked the retry_callback() - and that has returned true;
@@ -779,7 +747,8 @@ static void * job_queue_run_EXIT_callback( void * arg ) {
         job_queue_change_node_status(job_queue , node , JOB_QUEUE_WAITING);
       } else {
         // It's time to call it a day
-        job_queue_run_EXIT_callback__(job_queue , node);
+
+        job_queue_node_run_EXIT_callback( node );
         job_queue_change_node_status(job_queue , node , JOB_QUEUE_FAILED);
       }
     }
@@ -803,7 +772,7 @@ static void * job_queue_run_DO_KILL_callback( void * arg ) {
     job_queue_node_free_driver_data( node , job_queue->driver );
 
     // It's time to call it a day
-    job_queue_run_EXIT_callback__(job_queue, node);
+    job_queue_node_run_EXIT_callback( node );
     job_queue_change_node_status(job_queue, node, JOB_QUEUE_IS_KILLED);
   }
   job_list_unlock(job_queue->job_list );
@@ -1154,6 +1123,9 @@ void job_queue_run_jobs_threaded(job_queue_type * queue , int num_total_run, boo
 
 int job_queue_add_job(job_queue_type * queue ,
                       const char * run_cmd ,
+                      job_callback_ftype * done_callback,
+                      job_callback_ftype * retry_callback,
+                      job_callback_ftype * exit_callback,
                       void * callback_arg ,
                       int num_cpu ,
                       const char * run_path ,
@@ -1172,7 +1144,10 @@ int job_queue_add_job(job_queue_type * queue ,
                                                        num_cpu ,
                                                        queue->ok_file ,
                                                        queue->status_file ,
-                                                       queue->exit_file,                                                       
+                                                       queue->exit_file,
+                                                       done_callback ,
+                                                       retry_callback ,
+                                                       exit_callback ,
                                                        callback_arg );
     if (node) {
       job_list_get_wrlock( queue->job_list );
@@ -1202,24 +1177,12 @@ UTIL_SAFE_CAST_FUNCTION( job_queue , JOB_QUEUE_TYPE_ID)
    job_queue_set_driver() first.
 */
 
-job_queue_type * job_queue_alloc_w_callback(int  max_submit               ,
-                                            const char * ok_file ,
-                                            const char * status_file ,
-                                            const char * exit_file,
-                                            job_callback_ftype * done_callback,
-                                            job_callback_ftype * retry_callback,
-                                            job_callback_ftype * exit_callback) {
-   job_queue_type * job_queue = job_queue_alloc(max_submit, ok_file, status_file, exit_file);
-   job_queue->done_callback = done_callback;
-   job_queue->retry_callback = retry_callback;
-   job_queue->exit_callback = exit_callback;
-   return job_queue;
-}
-
 job_queue_type * job_queue_alloc(int  max_submit               ,
                                  const char * ok_file ,
                                  const char * status_file ,
-                                 const char * exit_file) {
+                                 const char * exit_file ) {
+
+
 
   job_queue_type * queue  = util_malloc(sizeof * queue );
   UTIL_TYPE_ID_INIT( queue , JOB_QUEUE_TYPE_ID);
@@ -1240,9 +1203,6 @@ job_queue_type * job_queue_alloc(int  max_submit               ,
   queue->work_pool        = NULL;
   queue->job_list         = job_list_alloc(  );
   queue->status           = job_queue_status_alloc( );
-  queue->done_callback    = NULL;
-  queue->retry_callback   = NULL;
-  queue->exit_callback    = NULL;
 
   pthread_mutex_init( &queue->run_mutex    , NULL );
 

--- a/libjob_queue/tests/job_job_queue_test.c
+++ b/libjob_queue/tests/job_job_queue_test.c
@@ -41,7 +41,7 @@ void submit_jobs_to_queue(job_queue_type * queue, test_work_area_type * work_are
       submitted_slowjobs++;
     }
 
-    job_queue_add_job(queue, executable_to_run, NULL, 1, runpath, "Testjob", 2, (const char *[2]) {runpath, sleeptime});
+    job_queue_add_job(queue, executable_to_run, NULL, NULL, NULL, NULL, 1, runpath, "Testjob", 2, (const char *[2]) {runpath, sleeptime});
     free(runpath);
   }
   test_assert_int_equal( number_of_jobs , job_queue_get_active_size(queue) );
@@ -115,7 +115,7 @@ void run_and_monitor_jobs(char * executable_to_run,
     char * sleeptime = util_alloc_sprintf("%d", job_run_time);
 
     util_make_path(runpath);
-    job_queue_add_job(queue, executable_to_run, NULL, 1, runpath, "Testjob", 2, (const char *[2]) {runpath, sleeptime});
+    job_queue_add_job(queue, executable_to_run, NULL, NULL, NULL, NULL, 1, runpath, "Testjob", 2, (const char *[2]) {runpath, sleeptime});
     job_run_time += interval_between_jobs;
 
     free(sleeptime);

--- a/libjob_queue/tests/job_queue_stress_test.c
+++ b/libjob_queue/tests/job_queue_stress_test.c
@@ -96,7 +96,7 @@ job_type ** alloc_jobs( rng_type * rng , int num_jobs , const char * cmd) {
 
 
 
-bool callback( job_queue_type * job_queue, void * arg ) {
+bool callback( void * arg ) {
   job_type * job = job_safe_cast( arg );
   usleep( job->callback_usleep );
   job->callback_run = true;
@@ -108,7 +108,7 @@ void * submit_job__( void * arg ) {
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
   job_type * job = job_safe_cast( arg_pack_iget_ptr( arg_pack , 0 ) );
   job_queue_type * queue = arg_pack_iget_ptr( arg_pack , 1 );
-  job->queue_index = job_queue_add_job( queue  , job->cmd , job , 1 , job->run_path , job->run_path , job->argc , (const char **) job->argv );
+  job->queue_index = job_queue_add_job( queue  , job->cmd , callback , NULL , NULL , job , 1 , job->run_path , job->run_path , job->argc , (const char **) job->argv );
 
   if (job->queue_index >= 0)
     usleep( job->submit_usleep );
@@ -274,8 +274,7 @@ int main(int argc , char ** argv) {
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
   job_type **jobs = alloc_jobs( rng , number_of_jobs , job);
 
-  //job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "STATUS", "ERROR");
-  job_queue_type * queue = job_queue_alloc_w_callback(number_of_jobs, "OK", "STATUS", "ERROR", callback, NULL, NULL);
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_manager_type * queue_manager = job_queue_manager_alloc( queue );
 

--- a/libjob_queue/tests/job_queue_timeout_test.c
+++ b/libjob_queue/tests/job_queue_timeout_test.c
@@ -88,7 +88,7 @@ void submit_jobs(job_queue_type * queue, int num_jobs, job_type ** jobs) {
   for (int i = 0; i < num_jobs; i++) {
     job_type * job = jobs[i];
 
-    job->queue_index = job_queue_add_job(queue, job->cmd, job, 1, job->run_path, job->run_path,
+    job->queue_index = job_queue_add_job(queue, job->cmd, NULL, NULL, NULL, job, 1, job->run_path, job->run_path,
             job->argc, (const char **) job->argv);
   }
 }


### PR DESCRIPTION
Have changed the job_queue retry callback to *not* access the `job_queue` instance.

Have reverted recent changes in the job_queue handling of callbacks:

1. The callback are invoked by the `job_node`.
2. The callbacks are owned by the `job_node`.
3. The `job_queue` constructor does *not* take callback arguments.
 